### PR TITLE
DM-13900: install headers under include dir

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -28,5 +28,16 @@ install()
 {
 	clean_old_install
 	scons install prefix=$PREFIX version=$VERSION
+    # Install headers under 'include' directory
+    # in case the user wants to delete 'src'.
+    mkdir -p $PREFIX/include
+    cp config.h $PREFIX/include/
+    cp src/*.h $PREFIX/include/
+    mkdir -p $PREFIX/include/wcs
+    cp src/wcs/*.h $PREFIX/include/wcs
+    mkdir -p $PREFIX/include/levmar/
+    cp src/levmar/*.h $PREFIX/include/levmar
+    mkdir -p $PREFIX/include/fits
+    cp src/fits/*.h $PREFIX/include/fits
 }
 

--- a/ups/psfex.cfg
+++ b/ups/psfex.cfg
@@ -10,7 +10,7 @@ config = lsst.sconsUtils.Configuration(
     __file__,
     headers=[],
     libs=["psfex"],
-    includeFileDirs=["src"],
+    includeFileDirs=["include"],
     hasDoxygenInclude=False, hasDoxygenTag=False,
     hasSwigFiles=True,
 )


### PR DESCRIPTION
To make them immune from stripping the src directory from the install
(as is done in Docker and binary builds).